### PR TITLE
Remove header navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,11 +28,6 @@ function App() {
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
           <span style={{ fontSize: '1.25rem', fontWeight: 700, letterSpacing: '-0.03em', color: '#fff' }}>Meta Ad Fatigue</span>
         </div>
-        <nav style={{ display: 'flex', gap: '1.5rem', marginLeft: 'auto', marginRight: 'auto' }}>
-          {['Dashboard', 'Projects', 'Albums', 'Brand', 'Admin'].map(tab => (
-            <span key={tab}>{tab}</span>
-          ))}
-        </nav>
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <button style={{ background: '#18181b', color: '#e4e4e7', padding: '0.5rem 1rem', borderRadius: '9999px', fontSize: '0.9rem', border: '1px solid #27272a' }}>Org ▼</button>
           <div className="profile-circle">U</div>

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,9 @@ header {
   font-size: 1.25rem;
   font-weight: bold;
   letter-spacing: -0.02em;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 .main-panel {
   background: #23232b;


### PR DESCRIPTION
## Summary
- drop nav bar from header
- make the header layout flex so the logo and profile info align horizontally

## Testing
- `npm run build` *(fails: cannot find modules)*
- `npm run lint` *(fails: cannot find modules)*